### PR TITLE
Feat: Create getting CSS properties from Tailwind CSS

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ async function getUserCssData() {
 
 async function main() {
   const cssInfo = await getUserCssData();
+  console.log(cssInfo);
 }
 
 main();

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 import fs from "fs";
 import path from "path";
 import { getStyledComponentsCss } from "./styledComponents.js";
+import { getTailwindCss } from "./tailwindCss.js";
 
 const currentPath = process.cwd();
 
@@ -16,11 +17,11 @@ async function getUserCssData() {
 
       if (fileContents.includes('"styled-components"')) {
         getStyledComponentsCss(currentPath, cssInfo);
-      } else {
+      } else if (fileContents.includes("tailwindcss")) {
+        cssInfo.push(...(await getTailwindCss(currentPath)));
       }
     }
   }
-  console.log(cssInfo);
 
   return cssInfo;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.6.7"
       },
       "bin": {
-        "cyc2": "main.js"
+        "cyc": "main.js"
       },
       "devDependencies": {
         "@babel/parser": "^7.23.9",

--- a/tailwindCss.js
+++ b/tailwindCss.js
@@ -1,0 +1,211 @@
+import os from "os";
+import fs from "fs";
+import path from "path";
+import postcss from "postcss";
+import traverse from "@babel/traverse";
+import { parse } from "@babel/parser";
+import { execSync } from "child_process";
+
+function copyFiles(sourceDir, targetDir) {
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { recursive: true });
+  }
+
+  const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (
+      [
+        "node_modules",
+        ".DS_Store",
+        ".git",
+        ".github",
+        "dist",
+        "build",
+        "out",
+      ].includes(entry.name)
+    ) {
+      continue;
+    }
+
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copyFiles(sourcePath, targetPath);
+    } else {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
+function findBuildDirectory(directoryPath) {
+  const entries = fs.readdirSync(directoryPath);
+  const buildDirectory = entries.find(entry =>
+    ["build", "out", "dist"].includes(entry),
+  );
+
+  return path.join(directoryPath, buildDirectory);
+}
+
+function traverseDirectory(directoryPath, callback) {
+  const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      traverseDirectory(fullPath, callback);
+    } else {
+      callback(fullPath);
+    }
+  }
+}
+
+function getCssFilePath(directoryPath) {
+  let cssFilePath = "";
+
+  traverseDirectory(directoryPath, filePath => {
+    if (filePath.endsWith(".css")) {
+      cssFilePath = filePath;
+    }
+  });
+
+  return cssFilePath;
+}
+
+async function getTailwindCssProperties() {
+  const tempDir = path.join(os.tmpdir(), "build-folder");
+
+  copyFiles(process.cwd(), tempDir);
+
+  process.chdir(tempDir);
+  execSync("npm install; npm run build");
+
+  const buildDirectoryPath = findBuildDirectory(process.cwd());
+  const cssFilePath = getCssFilePath(buildDirectoryPath);
+  const css = fs.readFileSync(cssFilePath, "utf8");
+
+  const cssPropertiesAndTwInfo = await postcss()
+    .process(css, { from: cssFilePath })
+    .then(result => {
+      const cssProperties = [];
+      const root = result.root;
+
+      root.walkDecls(decl => {
+        if (decl.parent.selector.startsWith(".")) {
+          cssProperties.push({ [decl.prop]: decl.parent.selector });
+        }
+      });
+
+      return cssProperties;
+    });
+
+  return cssPropertiesAndTwInfo;
+}
+
+function parseFileToAST(filePath) {
+  const fileContent = fs.readFileSync(filePath, "utf-8");
+  return parse(fileContent, {
+    sourceType: "module",
+    plugins: ["jsx", "typescript"],
+  });
+}
+
+function extractTailwindClasses(filePath) {
+  const ast = parseFileToAST(filePath);
+  const tailwindClasses = new Set();
+
+  traverse.default(ast, {
+    JSXAttribute({ node }) {
+      if (node.name.name === "className") {
+        if (node.value.type === "StringLiteral") {
+          node.value.value.split(" ").forEach(className =>
+            tailwindClasses.add({
+              className: className,
+              path: `${filePath}:${node.value.loc.start.line}`,
+            }),
+          );
+        } else if (
+          node.value.type === "JSXExpressionContainer" &&
+          node.value.expression.type === "StringLiteral"
+        ) {
+          node.value.expression.value
+            .split(" ")
+            .forEach(className => tailwindClasses.add(className));
+        }
+      }
+    },
+  });
+
+  return [...tailwindClasses];
+}
+
+function extractTailwindClassesFromDirectory(
+  directoryPath,
+  pathAndTailwindClasses,
+) {
+  const files = fs.readdirSync(directoryPath);
+
+  files.forEach(file => {
+    const filePath = path.join(directoryPath, file);
+    const stats = fs.statSync(filePath);
+
+    if (stats.isFile() && /\.(js|jsx|ts|tsx)$/.test(file)) {
+      if (!filePath.includes("node_modules")) {
+        const tailwindClasses = extractTailwindClasses(filePath);
+
+        if (tailwindClasses.length > 0) {
+          pathAndTailwindClasses.push({
+            filePath: filePath,
+            tailwindClasses: [...tailwindClasses],
+          });
+        }
+      }
+    } else if (stats.isDirectory()) {
+      extractTailwindClassesFromDirectory(filePath, pathAndTailwindClasses);
+    }
+  });
+
+  return pathAndTailwindClasses;
+}
+
+function createCssInfo(pathAndTailwindClasses, cssPropertiesAndTwInfo) {
+  pathAndTailwindClasses.forEach(info => {
+    const cssProperties = new Set();
+    info.cssMatching = [];
+    info.cssProperties = [];
+
+    info.tailwindClasses.forEach(tailwindClass => {
+      cssPropertiesAndTwInfo.forEach(item => {
+        const cssPropertyName = Object.keys(item)[0];
+        const cssPropertyValue = item[cssPropertyName];
+
+        if (
+          cssPropertyValue.includes(tailwindClass.className) &&
+          !cssPropertyName.includes("--tw-")
+        ) {
+          info.cssMatching.push({ [cssPropertyName]: tailwindClass.className });
+          info.cssProperties.push({
+            property: cssPropertyName,
+            line: tailwindClass.path,
+          });
+          cssProperties.add(cssPropertyName);
+        }
+      });
+    });
+  });
+}
+
+async function getTailwindCss(projectDirectory) {
+  const pathAndTailwindClasses = [];
+
+  const cssPropertiesAndTwInfo = await getTailwindCssProperties();
+
+  extractTailwindClassesFromDirectory(projectDirectory, pathAndTailwindClasses);
+  createCssInfo(pathAndTailwindClasses, cssPropertiesAndTwInfo);
+
+  return pathAndTailwindClasses;
+}
+
+export { getTailwindCss };

--- a/tailwindCss.js
+++ b/tailwindCss.js
@@ -173,7 +173,6 @@ function extractTailwindClassesFromDirectory(
 
 function createCssInfo(pathAndTailwindClasses, cssPropertiesAndTwInfo) {
   pathAndTailwindClasses.forEach(info => {
-    const cssProperties = new Set();
     info.cssMatching = [];
     info.cssProperties = [];
 
@@ -191,7 +190,6 @@ function createCssInfo(pathAndTailwindClasses, cssPropertiesAndTwInfo) {
             property: cssPropertyName,
             line: tailwindClass.path,
           });
-          cssProperties.add(cssPropertyName);
         }
       });
     });
@@ -200,7 +198,6 @@ function createCssInfo(pathAndTailwindClasses, cssPropertiesAndTwInfo) {
 
 async function getTailwindCss(projectDirectory) {
   const pathAndTailwindClasses = [];
-
   const cssPropertiesAndTwInfo = await getTailwindCssProperties();
 
   extractTailwindClassesFromDirectory(projectDirectory, pathAndTailwindClasses);


### PR DESCRIPTION
# [npm package] Tailwind CSS 프로젝트에서 사용자 CSS 정보 가져오기
- https://dune-hammer-c89.notion.site/npm-package-Tailwind-CSS-CSS-467f315b27194fee94cf3e92475343d4?pvs=4

## Description
- Tailwind CSS는 정해진 클래스를 HTML에 직접 적용하여 스타일을 지정하는 Utility-first CSS 중 하나입니다. 따라서 정해진 클래스를 사용하기 때문에 이 클래스가 어떠한 CSS 속성을 가지는 지를 변환해야 합니다.
- Tailwind CSS는 빌드 후에 하나의 css 파일에서 정보를 가져올 수 있기 때문에 모든 css 정보 및 tailwind CSS class 이름을 가져올 수 있습니다. 따라서 빌드를 하여 로직을 구현하였습니다.
- 빌드할 고려했던 점은 다음과 같습니다:
    - 사용자 프로젝트에 직접 build하는 방법을 생각하였으나 잘못 되었을 시 미치는 영향 때문에 node.js의 os 모듈을 사용하기로 결정하였습니다. os 모듈 중 tmpdir() 함수는 시스템의 기본 임시 파일 디렉토리의 경로를 반환합니다. 따라서 이 경로에 폴더를 복사한 후에 빌드를 진행하였습니다.

<br/>
- Tailwind CSS 클래스를 CSS 속성으로 변환하는 방법에는 PostCSS 모듈을 사용하였습니다. 그 이유는 이전에 문자열을 통해 하드 코딩을 진행했을 시 생기는 예외 케이스들과 정확도가 떨어졌기 때문입니다. PostCSS는 Tailwind CSS를 변환해주는데 그 중 walkDecls() 메서드는 PostCSS 트리의 선언(속성과 값) 노드만을 대상으로 순회합니다. 따라서 노드를 순회하면서 모든 CSS 속성을 가져올 수 있었습니다.

<br/>
- Tailwind CSS class를 가져올 때는 AST를 사용하여 정확성과 효율성을 높였습니다. AST를 통해 코드 구조를 파악하고, CSS 클래스를 포함하는 요소를 정밀하게 식별하였습니다.

## Focus
- 다소 개념이 어려울 수 있습니다.

## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
