### PR TITLE
Feat: Show results with figlet

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,9 @@ import { getTailwindCss } from "./tailwindCss.js";
 import { checkCssCompatibility } from "./cssCompatibility.js";
 import { getStyledComponentsCss } from "./styledComponents.js";
 import { selectBrowsersAndVersions } from "./userSelection.js";
+import { renderResult } from "./result.js";
+import chalk from "chalk";
+import figlet from "figlet";
 
 const currentPath = process.cwd();
 
@@ -32,6 +35,35 @@ async function main() {
   const userSelections = await selectBrowsersAndVersions();
   const cssInfo = await getUserCssData();
   const result = await checkCssCompatibility(cssInfo, userSelections);
+  const resultToShow = renderResult(userSelections, result);
+
+  figlet(
+    "Check Your CSS",
+    {
+      font: "slant",
+    },
+    function (err, data) {
+      if (err) {
+        console.log("Something went wrong...");
+        console.dir(err);
+        return;
+      }
+      // 아스키 아트에 색상 적용
+      console.log(chalk.redBright.bold(data));
+      Object.values(resultToShow).forEach(notSupport => {
+        console.log(`Property: ${notSupport.property}`);
+        notSupport.lines.forEach(line => {
+          console.log(`Used At: ${line}`);
+        });
+
+        notSupport.notices.forEach(notice => {
+          console.log(`Compatibility: ${notice}`);
+        });
+
+        console.log(" ");
+      });
+    },
+  );
 }
 
 main();

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ async function main() {
         console.dir(err);
         return;
       }
-      // 아스키 아트에 색상 적용
+
       console.log(chalk.redBright.bold(data));
       Object.values(resultToShow).forEach(notSupport => {
         console.log(`Property: ${notSupport.property}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,13 @@
       "dependencies": {
         "@mdn/browser-compat-data": "^5.5.10",
         "axios": "^1.6.7",
-        "inquirer": "^9.2.15"
+        "chalk": "^5.3.0",
+        "figlet": "^1.7.0",
+        "inquirer": "^9.2.15",
+        "postcss": "^8.4.35"
       },
       "bin": {
-        "cyc3": "main.js"
+        "cyc": "main.js"
       },
       "devDependencies": {
         "@babel/parser": "^7.23.9",
@@ -987,15 +990,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -1741,6 +1740,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -1867,6 +1882,17 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figlet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
+      "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==",
+      "bin": {
+        "figlet": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/figures": {
@@ -2387,17 +2413,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/inquirer/node_modules/cli-cursor": {
@@ -3060,18 +3075,6 @@
         "url": "https://opencollective.com/lint-staged"
       }
     },
-    "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/listr2": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.0.1.tgz",
@@ -3128,6 +3131,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/log-update": {
@@ -3315,6 +3333,23 @@
       "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -3534,6 +3569,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/ora/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3667,6 +3717,11 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3689,6 +3744,33 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -4145,6 +4227,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
   "dependencies": {
     "@mdn/browser-compat-data": "^5.5.10",
     "axios": "^1.6.7",
-    "inquirer": "^9.2.15"
+    "chalk": "^5.3.0",
+    "figlet": "^1.7.0",
+    "inquirer": "^9.2.15",
+    "postcss": "^8.4.35"
   }
 }

--- a/result.js
+++ b/result.js
@@ -1,0 +1,44 @@
+function renderResult(userSelections, result) {
+  const resultToShow = {};
+  userSelections.forEach(selection => {
+    result.forEach(propertyInfo => {
+      if (propertyInfo[selection.browser]) {
+        propertyInfo[selection.browser].compatibilityMessage =
+          `${propertyInfo[selection.browser].property} is supported ${selection.browser} from version ${propertyInfo[selection.browser].versionsSupport[0]} and higher.`;
+      }
+    });
+  });
+
+  userSelections.forEach(selection => {
+    result.forEach(propertyInfo => {
+      if (
+        propertyInfo[selection.browser] &&
+        propertyInfo[selection.browser].compatibility[0] !== "y"
+      ) {
+        if (resultToShow[propertyInfo[selection.browser].property]) {
+          resultToShow[propertyInfo[selection.browser].property].lines.push(
+            propertyInfo[selection.browser].line,
+          );
+          resultToShow[propertyInfo[selection.browser].property].notices.push(
+            propertyInfo[selection.browser].compatibilityMessage,
+          );
+        } else {
+          resultToShow[propertyInfo[selection.browser].property] = {
+            property: propertyInfo[selection.browser].property,
+            lines: [propertyInfo[selection.browser].line],
+            notices: [propertyInfo[selection.browser].compatibilityMessage],
+          };
+        }
+      }
+    });
+  });
+
+  Object.values(resultToShow).forEach(dup => {
+    dup.lines = [...new Set(dup.lines)];
+    dup.notices = [...new Set(dup.notices)];
+  });
+
+  return resultToShow;
+}
+
+export { renderResult };


### PR DESCRIPTION
# Title
- [호환성 결과를 토대로 사용자에게 호환성 정보 보여주기](https://dune-hammer-c89.notion.site/npm-package-b851512911d042fb953cece853b85d60?pvs=4)

## Description
- result의 결과값을 토대로 사용자에게 보여줄 내용을 정리한다.
 ex) Property: transition
       Used At: /Users/heeseung/Desktop/reactree-frontend/src/components/DirectorySelection.js:34
       Used At: /Users/heeseung/Desktop/reactree-frontend/src/components/Modal.js:16
       Compatibility: transition is supported Chrome from version 26 and higher.
       Compatibility: transition is supported FireFox from version 16 and higher.
- 결과를 figlet과 chalk를 사용하여 스타일링을 한다.

## Focus
- 사용자에게 보여지는 콘솔창을 어떻게 하면 조금 더 사용자 친화적으로 보일지 생각해봐야 할 것 같습니다.

## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
