### PR TITLE
Feat: refactor resultjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "postcss": "^8.4.35"
       },
       "bin": {
-        "cyc": "main.js"
+        "cyc3": "main.js"
       },
       "devDependencies": {
         "@babel/parser": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier": "^3.2.5"
   },
   "bin": {
-    "cyc": "./main.js"
+    "cyc3": "./main.js"
   },
   "dependencies": {
     "@mdn/browser-compat-data": "^5.5.10",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier": "^3.2.5"
   },
   "bin": {
-    "cyc3": "./main.js"
+    "cyc": "./main.js"
   },
   "dependencies": {
     "@mdn/browser-compat-data": "^5.5.10",

--- a/result.js
+++ b/result.js
@@ -1,3 +1,5 @@
+import chalk from "chalk";
+
 function renderResult(userSelections, result) {
   const resultToShow = {};
   userSelections.forEach(selection => {
@@ -11,25 +13,33 @@ function renderResult(userSelections, result) {
 
   userSelections.forEach(selection => {
     result.forEach(propertyInfo => {
-      if (
-        propertyInfo[selection.browser] &&
-        propertyInfo[selection.browser].compatibility[0] !== "y"
-      ) {
-        if (resultToShow[propertyInfo[selection.browser].property]) {
-          resultToShow[propertyInfo[selection.browser].property].lines.push(
-            propertyInfo[selection.browser].line,
-          );
-          resultToShow[propertyInfo[selection.browser].property].notices.push(
-            propertyInfo[selection.browser].compatibilityMessage,
-          );
-        } else {
-          resultToShow[propertyInfo[selection.browser].property] = {
-            property: propertyInfo[selection.browser].property,
-            lines: [propertyInfo[selection.browser].line],
-            notices: [propertyInfo[selection.browser].compatibilityMessage],
-          };
-        }
+      const browserInfo = propertyInfo[selection.browser];
+
+      if (!browserInfo || browserInfo.compatibility[0] === "y") {
+        return;
       }
+
+      const { property, line, compatibilityMessage } = browserInfo;
+      const resultKey =
+        resultToShow[property] ||
+        (resultToShow[property] = {
+          property,
+          lines: [],
+          notices: [],
+        });
+
+      let lineInfo = line;
+
+      if (browserInfo.cssMatching) {
+        const tailwindClassInfo = browserInfo.cssMatching[property];
+        const tailwindClass = tailwindClassInfo.find(
+          info => info.path === line,
+        );
+        lineInfo = `${chalk.green(tailwindClass.className)} ${line}`;
+      }
+
+      resultKey.lines.push(lineInfo);
+      resultKey.notices.push(compatibilityMessage);
     });
   });
 


### PR DESCRIPTION
# 결과 데이터 가져오는 함수 수정

## Description
- 결과 데이터를 가져오는 함수 중에 Tailwind CSS 클래스를 보여주기 위해 일부 로직을 수정하였습니다.
- 로직의 경우 Taiiwind CSS 데이터를 가져올 때 사용하는 cssMatching이 있을 경우 result 값을 바꿔주는 것으로 진행하였습니다.

## Focus
- 로직의 이상이 있을 경우 알려주시면 감사하겠습니다.

## Etc
- 결과 화면
![image](https://github.com/TeamTitans1/checkyourcss-npm/assets/128145017/2f5c5ede-fbde-4fa1-9437-2315d0f36e08)

## Checklists
- [ ] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [ ] 코드 스타일을 잘 확인했는가?
