### PR TITLE
Feat: change incompatible css to prefix

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,21 +1,24 @@
 #!/usr/bin/env node
 import fs from "fs";
 import path from "path";
-import { getTailwindCss } from "./tailwindCss.js";
-import { checkCssCompatibility } from "./cssCompatibility.js";
-import { getStyledComponentsCss } from "./styledComponents.js";
-import { selectBrowsersAndVersions } from "./userSelection.js";
+import chalk from "chalk";
+import figlet from "figlet";
 import { loadConfig } from "./configLoader.js";
 import { createConfig } from "./create-config.js";
 import { renderResult } from "./result.js";
-import chalk from "chalk";
-import figlet from "figlet";
+import { getTailwindCss } from "./tailwindCss.js";
+import { changeToPolyfill } from "./polyfill.js";
+import { checkCssCompatibility } from "./cssCompatibility.js";
+import { getStyledComponentsCss } from "./styledComponents.js";
+import { selectBrowsersAndVersions } from "./userSelection.js";
 
 const currentPath = process.cwd();
 const args = process.argv.slice(2);
 
 if (args.includes("--init")) {
   createConfig();
+} else if (args.includes("--fix")) {
+  changeToPolyfill();
 } else {
   main();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "checkyourcss",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkyourcss",
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@mdn/browser-compat-data": "^5.5.10",
@@ -17,11 +18,13 @@
         "postcss": "^8.4.35"
       },
       "bin": {
-        "cyc": "main.js"
+        "cyc": "main.js",
+        "cyc2": "polyfill.js"
       },
       "devDependencies": {
         "@babel/parser": "^7.23.9",
         "@babel/traverse": "^7.23.9",
+        "autoprefixer": "^10.4.17",
         "eslint": "^8.56.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.1.0",
@@ -840,6 +843,43 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.17",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+      "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.22.2",
+        "caniuse-lite": "^1.0.30001578",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
@@ -939,6 +979,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -988,6 +1060,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001589",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
+      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "5.3.0",
@@ -1235,6 +1327,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.681",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.681.tgz",
+      "integrity": "sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg==",
+      "dev": true
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -1387,6 +1485,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2016,6 +2123,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs.realpath": {
@@ -3358,6 +3478,21 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-releases": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
@@ -3772,6 +3907,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4594,6 +4735,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/parser": "^7.23.9",
     "@babel/traverse": "^7.23.9",
+    "autoprefixer": "^10.4.17",
     "eslint": "^8.56.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.1.0",

--- a/polyfill.js
+++ b/polyfill.js
@@ -68,7 +68,7 @@ async function addPrefixes(css, browserQuery) {
 
 async function getCssPolyfills(userSelections, content) {
   const result = userSelections.map(async selection => {
-    const browserQuery = `${selection.browser} ${selection.version}`; // Firefox 14 버전을 지정
+    const browserQuery = `${selection.browser} ${selection.version}`;
     const finalCss = await addPrefixes(content, browserQuery);
     const splittedCss = finalCss.split(";");
     const temp = [];

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import postcss from "postcss";
+import traverse from "@babel/traverse";
+import autoprefixer from "autoprefixer";
+import { parse } from "@babel/parser";
+import { loadConfig } from "./configLoader.js";
+import { selectBrowsersAndVersions } from "./userSelection.js";
+
+function readFileContent(fullPath) {
+  return fs.readFileSync(fullPath, "utf8");
+}
+
+function getCssText(fileContent) {
+  const cssText = [];
+  const ast = parse(fileContent, {
+    sourceType: "unambiguous",
+    plugins: ["jsx", "typescript"],
+  });
+
+  traverse.default(ast, {
+    TaggedTemplateExpression(path) {
+      const isStyledComponent =
+        path.node.tag.type === "MemberExpression" &&
+        path.node.tag.object.name === "styled";
+
+      if (isStyledComponent) {
+        path.node.quasi.quasis.forEach(element => {
+          cssText.push(element.value.raw);
+        });
+      }
+    },
+  });
+
+  return cssText;
+}
+
+function extractCssProperties(cssText) {
+  const properties = [];
+
+  cssText.forEach(text => {
+    const cssProperties = text.split("\n");
+
+    cssProperties.forEach(property => {
+      const pattern = /([\w-]+)\s*:\s*([\w-]+)/g;
+      const matches = property.match(pattern);
+      if (matches) {
+        properties.push(matches[0] + ";");
+      }
+    });
+  });
+
+  return properties;
+}
+
+async function addPrefixes(css, browserQuery) {
+  const autoprefixerPlugin = autoprefixer({
+    overrideBrowserslist: [browserQuery],
+  });
+  const processedCss = await postcss(autoprefixerPlugin).process(css, {
+    from: undefined,
+  });
+
+  return processedCss.css;
+}
+
+async function getCssPolyfills(userSelections, content) {
+  const result = userSelections.map(async selection => {
+    const browserQuery = `${selection.browser} ${selection.version}`; // Firefox 14 버전을 지정
+    const finalCss = await addPrefixes(content, browserQuery);
+    const splittedCss = finalCss.split(";");
+    const temp = [];
+
+    for (let i = 1; i < splittedCss.length; i++) {
+      if (
+        splittedCss[i].includes("-webkit-") ||
+        splittedCss[i].includes("-moz-") ||
+        splittedCss[i].includes("-ms-") ||
+        splittedCss[i].includes("-o-")
+      ) {
+        continue;
+      } else {
+        if (
+          splittedCss[i - 1].includes("-webkit") ||
+          splittedCss[i - 1].includes("-moz") ||
+          splittedCss[i - 1].includes("-ms") ||
+          splittedCss[i - 1].includes("-o-")
+        ) {
+          let j = i - 1;
+          const info = { [splittedCss[i]]: [] };
+          while (
+            (splittedCss[j].includes("-webkit") ||
+              splittedCss[j].includes("-moz") ||
+              splittedCss[j].includes("-ms") ||
+              splittedCss[j].includes("-o")) &&
+            j >= 0
+          ) {
+            info[splittedCss[i]].push(splittedCss[j]);
+            j--;
+          }
+
+          temp.push(info);
+        }
+      }
+    }
+
+    return temp;
+  });
+
+  return await Promise.all(result);
+}
+
+function modifyFileContent(results, fileContent) {
+  results.flat().forEach(result => {
+    const keys = Object.keys(result);
+
+    keys.forEach(key => {
+      if (result[key].length > 1) {
+        const substitutionString = result[key]
+          .map(value => value + ";")
+          .join("\n");
+
+        fileContent = fileContent.replace(
+          new RegExp(key, "g"),
+          match => `${substitutionString}\n  ${match}`,
+        );
+      } else {
+        fileContent = fileContent.replace(
+          new RegExp(key, "g"),
+          match => `${result[key]};\n  ${match}`,
+        );
+      }
+    });
+  });
+
+  return fileContent;
+}
+
+function getStyledComponentsFiles(currentPath, files) {
+  const entries = fs.readdirSync(currentPath);
+
+  for (const entry of entries) {
+    if (
+      entry === "node_modules" ||
+      entry === "build" ||
+      entry === "out" ||
+      entry === "dist"
+    ) {
+      continue;
+    }
+
+    const filePath = path.join(currentPath, entry);
+    const stats = fs.statSync(filePath);
+
+    if (stats.isDirectory()) {
+      getStyledComponentsFiles(filePath, files);
+    } else {
+      const fileContent = readFileContent(filePath);
+      const styledComponentsRegex =
+        /from ['"]styled-components(?:\/native)?['"]|require\(['"]styled-components(?:\/native)?['"]\)/;
+
+      if (styledComponentsRegex.test(fileContent)) {
+        files.push(filePath);
+      }
+    }
+  }
+}
+
+async function changeStyledComponentsCss(filePath, userSelections) {
+  if (filePath === ".") {
+    const files = [];
+
+    getStyledComponentsFiles(process.cwd(), files);
+
+    const cssText = files.map(filePath => {
+      const content = readFileContent(filePath);
+
+      return getCssText(content);
+    });
+    const properties = [
+      ...new Set(extractCssProperties(cssText.flat(Infinity))),
+    ].join("");
+    const results = await getCssPolyfills(userSelections, properties);
+
+    files.forEach(file => {
+      let fileContent = readFileContent(file);
+      const modifiedContent = modifyFileContent(results, fileContent);
+
+      fs.writeFileSync(file, modifiedContent);
+    });
+  } else if (/.*\..+$/.test(filePath)) {
+    const fullPath = path.join(process.cwd(), filePath);
+    const fileContent = readFileContent(fullPath, "utf8");
+    const cssText = getCssText(fileContent);
+    const content = [...new Set(extractCssProperties(cssText))].join("");
+    const results = await getCssPolyfills(userSelections, content);
+    const modifiedContent = modifyFileContent(results, fileContent);
+
+    fs.writeFileSync(fullPath, modifiedContent);
+  }
+}
+
+async function changeToPolyfill() {
+  const filePath = process.argv[3];
+  const files = fs.readdirSync(process.cwd());
+  const userConfig = await loadConfig();
+  let configInfo;
+
+  if (!Object.keys(userConfig).length) {
+    configInfo = await selectBrowsersAndVersions();
+  } else {
+    configInfo = userConfig.browsers;
+  }
+
+  for (const file of files) {
+    if (file === "package.json") {
+      const fullPath = path.join(process.cwd(), file);
+      const fileContent = fs.readFileSync(fullPath, "utf8");
+
+      if (fileContent.includes('"styled-components"')) {
+        changeStyledComponentsCss(filePath, configInfo);
+      } else if (fileContent.includes("tailwindcss")) {
+      }
+    }
+  }
+}
+
+changeToPolyfill();
+
+export { changeToPolyfill };

--- a/polyfill.js
+++ b/polyfill.js
@@ -46,6 +46,7 @@ function extractCssProperties(cssText) {
     cssProperties.forEach(property => {
       const pattern = /([\w-]+)\s*:\s*([\w-]+)/g;
       const matches = property.match(pattern);
+
       if (matches) {
         properties.push(matches[0] + ";");
       }
@@ -90,6 +91,7 @@ async function getCssPolyfills(userSelections, content) {
         ) {
           let j = i - 1;
           const info = { [splittedCss[i]]: [] };
+
           while (
             (splittedCss[j].includes("-webkit") ||
               splittedCss[j].includes("-moz") ||
@@ -112,7 +114,7 @@ async function getCssPolyfills(userSelections, content) {
   return await Promise.all(result);
 }
 
-function modifyFileContent(results, fileContent) {
+function fixFileContent(results, fileContent) {
   results.flat().forEach(result => {
     const keys = Object.keys(result);
 
@@ -186,7 +188,7 @@ async function changeStyledComponentsCss(filePath, userSelections) {
 
     files.forEach(file => {
       let fileContent = readFileContent(file);
-      const modifiedContent = modifyFileContent(results, fileContent);
+      const modifiedContent = fixFileContent(results, fileContent);
 
       fs.writeFileSync(file, modifiedContent);
     });
@@ -196,7 +198,7 @@ async function changeStyledComponentsCss(filePath, userSelections) {
     const cssText = getCssText(fileContent);
     const content = [...new Set(extractCssProperties(cssText))].join("");
     const results = await getCssPolyfills(userSelections, content);
-    const modifiedContent = modifyFileContent(results, fileContent);
+    const modifiedContent = fixFileContent(results, fileContent);
 
     fs.writeFileSync(fullPath, modifiedContent);
   }


### PR DESCRIPTION
# [npm package] 호환되지 않는 CSS 변경하기
- https://dune-hammer-c89.notion.site/npm-package-CSS-fff9f5954c7f416bbe7abce20184d66a?pvs=4

## Description
- 사용자가 `cyc --fix /path` 형식으로 명령어를 입력하면 호환되지 않는 CSS 속성에 prefix를 붙여주는 기능을 구현하였습니다.
- 사용자가 원하는 경로의 파일에서 모든 CSS를 가져오고, 가져온 CSS를 autoprefixer를 이용하여 브라우저에 알맞는 prefix를 생성하였습니다.
  - autoprefixer는 지원해야 하는 브라우저 범위에 기반하여 필요한 접두사를 자동으로 추가해주는 도구 입니다.
- 변환된 CSS는 해당 위치를 찾아 replace 메서드를 이용하여 변환해주었습니다.

## Focus
- 차근차근 로직을 따져가면서 취약점을 알려주시면 감사하겠습니다.

## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
