### PR TITLE
Refactor: show suggestion on the result

### DIFF
--- a/cssCompatibility.js
+++ b/cssCompatibility.js
@@ -1,6 +1,5 @@
 import axios from "axios";
 import bcd from "@mdn/browser-compat-data" assert { type: "json" };
-import { decl } from "postcss";
 
 async function getCanIUseData() {
   try {

--- a/cssCompatibility.js
+++ b/cssCompatibility.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import bcd from "@mdn/browser-compat-data" assert { type: "json" };
+import { decl } from "postcss";
 
 async function getCanIUseData() {
   try {
@@ -13,7 +14,13 @@ async function getCanIUseData() {
   }
 }
 
-function getVersionCompatibility(selection, property, canIUseData, line) {
+function getVersionCompatibility(
+  selection,
+  property,
+  canIUseData,
+  line,
+  declaratives,
+) {
   const agentsData = canIUseData.agents;
   const browsers = {
     Chrome: {
@@ -91,6 +98,7 @@ function getVersionCompatibility(selection, property, canIUseData, line) {
         versionsNotSupport,
         versionsPartiallySupport,
         versionsSupport,
+        declaratives,
       },
     };
   } else if (property in bcd.css.properties) {
@@ -147,6 +155,7 @@ function getVersionCompatibility(selection, property, canIUseData, line) {
         line,
         versionsNotSupport,
         versionsSupport,
+        declaratives,
       },
     };
   }
@@ -193,6 +202,7 @@ async function checkCssCompatibility(cssInfo, userSelections) {
           property.property,
           canIUseData,
           property.line,
+          property.declaratives,
         );
 
         if (compatibilityInfo) {

--- a/main.js
+++ b/main.js
@@ -72,33 +72,22 @@ async function main() {
       console.log(chalk.redBright.bold(data));
       Object.values(resultToShow).forEach(notSupport => {
         console.log(
-          chalk.yellow.bold.italic(`Property: ${notSupport.property}`),
+          `${chalk.redBright("[Warning]")} ${chalk.greenBright.italic(notSupport.property)} is not supported in ${notSupport.notices}.`,
         );
 
-        if (!Object.keys(userConfig).length) {
-          notSupport.lines.forEach(line => {
-            console.log(`Used At: ${line}`);
-          });
-          notSupport.notices.forEach(notice => {
-            console.log(
-              chalk.underline.whiteBright(`Compatibility: ${notice}`),
-            );
+        console.log(chalk.yellow("[Suggestion]"));
+        if (notSupport.twClass.length > 0) {
+          notSupport.twClass.forEach((item, index) => {
+            console.log(` ${chalk(item)} ➝ ${notSupport.suggestion[index]}`);
           });
         } else {
-          if (userConfig.lineInfo) {
-            notSupport.lines.forEach(line => {
-              console.log(`Used At: ${line}`);
-            });
-          }
-
-          if (userConfig.compatibilityInfo) {
-            notSupport.notices.forEach(notice => {
-              console.log(
-                chalk.underline.whiteBright(`Compatibility: ${notice}`),
-              );
-            });
-          }
+          console.log(`${notSupport.suggestion[0]} `);
         }
+
+        console.log(chalk.blueBright("[Used At]"));
+        notSupport.lines.forEach(line => {
+          console.log(`${line}`);
+        });
 
         console.log(" ");
       });

--- a/main.js
+++ b/main.js
@@ -70,19 +70,20 @@ async function main() {
       }
 
       console.log(chalk.redBright.bold(data));
+
       Object.values(resultToShow).forEach(notSupport => {
         console.log(
           `${chalk.redBright("[Warning]")} ${chalk.greenBright.italic(notSupport.property)} is not supported in ${notSupport.notices}.`,
         );
 
         console.log(chalk.yellow("[Suggestion]"));
-        if (notSupport.twClass.length > 0) {
-          notSupport.twClass.forEach((item, index) => {
-            console.log(` ${chalk(item)} ➝ ${notSupport.suggestion[index]}`);
-          });
-        } else {
-          console.log(`${notSupport.suggestion[0]} `);
-        }
+        notSupport.suggestion.forEach(item => {
+          if (!item.includes(":")) {
+            console.log(`${item}:`);
+          } else {
+            console.log(`  ${item}`);
+          }
+        });
 
         console.log(chalk.blueBright("[Used At]"));
         notSupport.lines.forEach(line => {

--- a/polyfill.js
+++ b/polyfill.js
@@ -221,12 +221,9 @@ async function changeToPolyfill() {
 
       if (fileContent.includes('"styled-components"')) {
         changeStyledComponentsCss(filePath, configInfo);
-      } else if (fileContent.includes("tailwindcss")) {
       }
     }
   }
 }
-
-changeToPolyfill();
 
 export { changeToPolyfill };

--- a/result.js
+++ b/result.js
@@ -29,7 +29,6 @@ function renderResult(userSelections, result) {
           lines: [],
           notices: [],
           suggestion: [],
-          twClass: [],
         });
 
       let lineInfo = line;
@@ -55,13 +54,10 @@ function renderResult(userSelections, result) {
 
       resultKey.lines.push(lineInfo);
       resultKey.notices.push(compatibilityMessage);
-      resultKey.suggestion.push(processedCss.css);
-
-      if (propertyInfo[selection.browser].declaratives.twClass) {
-        resultKey.twClass.push(
-          propertyInfo[selection.browser].declaratives.twClass.slice(1),
-        );
-      }
+      resultKey.suggestion.push(
+        selection.browser,
+        `${propertyInfo[selection.browser].declaratives.twClass.slice(1)} ➝ ${processedCss.css}`,
+      );
     });
   });
 

--- a/result.js
+++ b/result.js
@@ -1,4 +1,6 @@
 import chalk from "chalk";
+import postcss from "postcss";
+import autoprefixer from "autoprefixer";
 
 function renderResult(userSelections, result) {
   const resultToShow = {};
@@ -6,7 +8,7 @@ function renderResult(userSelections, result) {
     result.forEach(propertyInfo => {
       if (propertyInfo[selection.browser]) {
         propertyInfo[selection.browser].compatibilityMessage =
-          `${propertyInfo[selection.browser].property} is supported ${selection.browser} from version ${propertyInfo[selection.browser].versionsSupport[0]} and higher.`;
+          `${selection.browser} ${propertyInfo[selection.browser].versionsSupport[0]} and higher`;
       }
     });
   });
@@ -26,6 +28,8 @@ function renderResult(userSelections, result) {
           property,
           lines: [],
           notices: [],
+          suggestion: [],
+          twClass: [],
         });
 
       let lineInfo = line;
@@ -35,17 +39,37 @@ function renderResult(userSelections, result) {
         const tailwindClass = tailwindClassInfo.find(
           info => info.path === line,
         );
-        lineInfo = `${chalk.green(tailwindClass.className)} ${line}`;
+        lineInfo = `${chalk.whiteBright(tailwindClass.className)} ${line}`;
       }
+
+      const browserQuery = `${selection.browser} ${selection.version}`;
+      const autoprefixerPlugin = autoprefixer({
+        overrideBrowserslist: [browserQuery],
+      });
+      const processedCss = postcss(autoprefixerPlugin).process(
+        propertyInfo[selection.browser].declaratives.decl,
+        {
+          from: undefined,
+        },
+      );
 
       resultKey.lines.push(lineInfo);
       resultKey.notices.push(compatibilityMessage);
+      resultKey.suggestion.push(processedCss.css);
+
+      if (propertyInfo[selection.browser].declaratives.twClass) {
+        resultKey.twClass.push(
+          propertyInfo[selection.browser].declaratives.twClass.slice(1),
+        );
+      }
     });
   });
 
   Object.values(resultToShow).forEach(dup => {
     dup.lines = [...new Set(dup.lines)];
     dup.notices = [...new Set(dup.notices)];
+    dup.suggestion = [...new Set(dup.suggestion)];
+    dup.twClass = [...new Set(dup.twClass)];
   });
 
   return resultToShow;

--- a/styledComponents.js
+++ b/styledComponents.js
@@ -88,17 +88,22 @@ function extractCSSProperties(path, cssProperties) {
     .forEach(quasiPath => {
       const cssText = quasiPath.node.value.raw;
       const startLine = quasiPath.node.loc.start.line;
-      const regex = /(\w+-?\w+)\s*:/g;
+      const regex = /([a-zA-Z-]+)\s*:\s*([^;]+);/g;
       let match;
 
       while ((match = regex.exec(cssText))) {
+        const declaratives = match[0];
         const property = match[1];
         const lineOffset = calculateLineOffset(
           cssText.substring(0, match.index),
         );
         const propertyLine = startLine + lineOffset;
 
-        cssProperties.add({ property, line: propertyLine });
+        cssProperties.add({
+          property,
+          line: propertyLine,
+          declaratives,
+        });
       }
     });
 }
@@ -137,8 +142,13 @@ function getStyledComponentsCss(directoryPath, styledComponentsCss) {
           fileContents,
           styledVariableNames,
         );
+
         cssProperties = cssProperties.map(info => {
-          return { property: info.property, line: `${filePath}:${info.line}` };
+          return {
+            property: info.property,
+            line: `${filePath}:${info.line}`,
+            declaratives: { decl: info.declaratives },
+          };
         });
       }
 

--- a/tailwindCss.js
+++ b/tailwindCss.js
@@ -92,7 +92,13 @@ async function getTailwindCssProperties() {
 
     root.walkDecls(decl => {
       if (decl.parent.selector.startsWith(".")) {
-        cssProperties.push({ [decl.prop]: decl.parent.selector });
+        cssProperties.push({
+          [decl.prop]: decl.parent.selector,
+          declaratives: {
+            twClass: decl.parent.selector,
+            decl: `${decl.prop}: ${decl.value};`,
+          },
+        });
       }
     });
 
@@ -194,6 +200,7 @@ function createCssInfo(pathAndTailwindClasses, cssPropertiesAndTwInfo) {
           info.cssProperties.push({
             property: cssPropertyName,
             line: tailwindClass.path,
+            declaratives: item.declaratives,
           });
         }
       });


### PR DESCRIPTION
# [npm package] 결과에 제안 부분 추가하기
- https://dune-hammer-c89.notion.site/npm-package-640a401d575c4085894880f0b7758f59?pvs=4

## Description
- 기존에 결과화면에 없던 'Suggestion'을 추가하였습니다.
- 'Suggestion'은 사용자가 지정한 브라우저 종류와 버전에서 호환되지 않는 CSS를 autoprefixer로 변환시켜 그 값을 나타내는 부분입니다.
- 기존의 CSS 속성에서 속성명만 가져왔지만 autoprefixer를 사용할 때는 선언부 전체를 가져와야 하기 때문에 `declaratives`라는 변수를 만들어 가져오게 되었습니다. 
 
## Focus
- 이전 코드에서 변경 부분이 있습니다. 잘 비교하면서 봐주시면 감사하겠습니다.

## Etc
![image](https://github.com/TeamTitans1/checkyourcss-npm/assets/128145017/38ade26b-2569-4e49-bef3-38ed22b1af81)

## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
